### PR TITLE
fix(POST): authorize code 200

### DIFF
--- a/lib/zoho_books/connection.rb
+++ b/lib/zoho_books/connection.rb
@@ -17,7 +17,7 @@ module ZohoBooks
     def self.post(url, body)
       response = HTTParty.post(url, body:, headers:)
 
-      return render_error(response) if response.code != 201
+      return render_error(response) unless [200, 201].include?(response.code)
 
       response
     end


### PR DESCRIPTION
Pour l'endpoint de mise à jour du statut de l'invoice, le response code est 200 et non 201, ce qui retourne à tort une `ZohoBooks::Error` en réponse au tailor admin